### PR TITLE
fix: Prevent axios interceptor from redirecting to login during logout

### DIFF
--- a/client/sanich-farms/src/hooks/useAuth.js
+++ b/client/sanich-farms/src/hooks/useAuth.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { setLoggingOut } from '../services/api';
 
 export const useAuth = () => {
   const [user, setUser] = useState(null);
@@ -37,10 +38,16 @@ export const useAuth = () => {
 
   // Logout function
   const logout = () => {
+    setLoggingOut(true); // Prevent axios interceptor redirect
     setUser(null);
     setToken(null);
     localStorage.removeItem('authToken');
     localStorage.removeItem('user');
+    
+    // Reset flag after a short delay
+    setTimeout(() => {
+      setLoggingOut(false);
+    }, 100);
   };
 
   // Update user data

--- a/client/sanich-farms/src/services/api.js
+++ b/client/sanich-farms/src/services/api.js
@@ -26,11 +26,14 @@ apiClient.interceptors.request.use(
   }
 );
 
+// Flag to prevent redirect during logout
+let isLoggingOut = false;
+
 // Response interceptor to handle errors
 apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
-    if (error.response?.status === 401) {
+    if (error.response?.status === 401 && !isLoggingOut) {
       // Token expired or invalid, clear auth data
       localStorage.removeItem('authToken');
       localStorage.removeItem('user');
@@ -39,6 +42,11 @@ apiClient.interceptors.response.use(
     return Promise.reject(error);
   }
 );
+
+// Export function to set logout flag
+export const setLoggingOut = (status) => {
+  isLoggingOut = status;
+};
 
 // Authentication API methods
 export const authAPI = {


### PR DESCRIPTION
- Add isLoggingOut flag to prevent 401 interceptor redirect during logout
- Export setLoggingOut function from api.js to control redirect behavior
- Update useAuth logout to set flag before clearing tokens
- Ensure logout navigates to homepage (/) instead of login page
- Reset flag after logout completion to restore normal error handling
- Fix issue where axios 401 interceptor was overriding logout navigation