### PR TITLE
debug: Add extensive logging and use window.location for logout redirect

### DIFF
--- a/client/sanich-farms/src/hooks/useAuth.js
+++ b/client/sanich-farms/src/hooks/useAuth.js
@@ -38,16 +38,19 @@ export const useAuth = () => {
 
   // Logout function
   const logout = () => {
+    console.log('Starting logout process...');
     setLoggingOut(true); // Prevent axios interceptor redirect
     setUser(null);
     setToken(null);
     localStorage.removeItem('authToken');
     localStorage.removeItem('user');
+    console.log('Auth data cleared, logging out flag set');
     
-    // Reset flag after a short delay
+    // Reset flag after a longer delay to ensure navigation completes
     setTimeout(() => {
       setLoggingOut(false);
-    }, 100);
+      console.log('Logout flag reset');
+    }, 1000);
   };
 
   // Update user data

--- a/client/sanich-farms/src/pages/UserDashboardPage.jsx
+++ b/client/sanich-farms/src/pages/UserDashboardPage.jsx
@@ -56,16 +56,16 @@ const UserDashboardPage = () => {
   };
 
   // LOGOUT UI FIX: Confirm logout action
-  const confirmLogout = () => {
+  const confirmLogout = async () => {
     try {
+      console.log('Confirm logout called');
+      
       // Clear authentication state (user data, tokens, localStorage)
       logout();
       
-      // Navigate to home page (not login page)
-      navigate('/');
-      
-      // Close modal
-      setShowLogoutModal(false);
+      console.log('Logout completed, using window.location to navigate to homepage...');
+      // Use window.location for a clean redirect that bypasses React Router
+      window.location.href = '/';
     } catch (error) {
       console.error('Logout error:', error);
       alert('There was an error logging out. Please try again.');

--- a/client/sanich-farms/src/services/api.js
+++ b/client/sanich-farms/src/services/api.js
@@ -33,11 +33,17 @@ let isLoggingOut = false;
 apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
-    if (error.response?.status === 401 && !isLoggingOut) {
-      // Token expired or invalid, clear auth data
-      localStorage.removeItem('authToken');
-      localStorage.removeItem('user');
-      window.location.href = '/';
+    if (error.response?.status === 401) {
+      console.log('401 error detected, isLoggingOut:', isLoggingOut);
+      if (!isLoggingOut) {
+        console.log('Redirecting to login page');
+        // Token expired or invalid, clear auth data
+        localStorage.removeItem('authToken');
+        localStorage.removeItem('user');
+        window.location.href = '/login';
+      } else {
+        console.log('Logout in progress, skipping redirect');
+      }
     }
     return Promise.reject(error);
   }


### PR DESCRIPTION
- Add console logging to track logout process flow
- Use window.location.href for homepage redirect to bypass React Router
- Increase logout flag timeout to 1000ms for better reliability
- Add debugging to axios interceptor to track 401 responses
- Revert api interceptor to redirect to /login for normal 401 errors
- Use full page redirect to prevent any component API calls after logout