### PR TITLE
feat: Implement navbar hide/show for dashboard mobile menu

### DIFF
--- a/client/sanich-farms/src/pages/UserDashboardPage.jsx
+++ b/client/sanich-farms/src/pages/UserDashboardPage.jsx
@@ -50,6 +50,17 @@ const UserDashboardPage = () => {
     };
   }, [showLogoutModal]);
 
+  // MOBILE MENU FIX: Cleanup navbar visibility on component unmount
+  useEffect(() => {
+    return () => {
+      // Ensure navbar is visible when leaving dashboard
+      const navbar = document.querySelector('header');
+      if (navbar) {
+        navbar.style.display = 'block';
+      }
+    };
+  }, []);
+
   // LOGOUT UI FIX: Show logout confirmation modal
   const handleLogout = () => {
     setShowLogoutModal(true);
@@ -79,10 +90,28 @@ const UserDashboardPage = () => {
 
   const toggleMobileMenu = () => {
     setIsMobileMenuOpen(!isMobileMenuOpen);
+    
+    // MOBILE MENU FIX: Hide/show navbar when dashboard menu toggles
+    const navbar = document.querySelector('header');
+    if (navbar) {
+      if (!isMobileMenuOpen) {
+        // Opening mobile menu - hide navbar
+        navbar.style.display = 'none';
+      } else {
+        // Closing mobile menu - show navbar
+        navbar.style.display = 'block';
+      }
+    }
   };
 
   const closeMobileMenu = () => {
     setIsMobileMenuOpen(false);
+    
+    // MOBILE MENU FIX: Show navbar when mobile menu is closed
+    const navbar = document.querySelector('header');
+    if (navbar) {
+      navbar.style.display = 'block';
+    }
   };
 
   return (


### PR DESCRIPTION
- Hide main navbar when dashboard mobile menu is opened
- Show main navbar when dashboard mobile menu is closed
- Add automatic navbar restoration on component unmount
- Improve mobile UX by preventing navbar/menu overlap
- Handle overlay click and all close scenarios
- Ensure navbar is always visible when leaving dashboard
- Use direct DOM manipulation for immediate navbar control