### PR TITLE
fix: resolve breadcrumb coverage issue on tablet and desktop screens

### DIFF
--- a/client/sanich-farms/src/components/Layout/MainLayout.jsx
+++ b/client/sanich-farms/src/components/Layout/MainLayout.jsx
@@ -12,24 +12,36 @@ const MainLayout = () => {
   useEffect(() => {
     const setNavbarHeight = () => {
       if (navbarRef.current) {
-        document.documentElement.style.setProperty('--navbar-height', `${navbarRef.current.offsetHeight}px`);
+        const height = navbarRef.current.offsetHeight;
+        document.documentElement.style.setProperty('--navbar-height', `${height}px`);
+        
+        // Add responsive padding to ensure breadcrumbs are never covered
+        const additionalPadding = window.innerWidth >= 1024 ? 12 : window.innerWidth >= 768 ? 8 : 4;
+        const totalPadding = height + additionalPadding;
+        document.documentElement.style.setProperty('--content-padding-top', `${totalPadding}px`);
       }
     };
 
     // Set height on mount and on resize
     setNavbarHeight();
     window.addEventListener('resize', setNavbarHeight);
+    
+    // Also recalculate on orientation change for mobile devices
+    window.addEventListener('orientationchange', () => {
+      setTimeout(setNavbarHeight, 100); // Small delay to let orientation change complete
+    });
 
-    // Cleanup listener on unmount
+    // Cleanup listeners on unmount
     return () => {
       window.removeEventListener('resize', setNavbarHeight);
+      window.removeEventListener('orientationchange', setNavbarHeight);
     };
   }, []);
 
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar ref={navbarRef} /> {/* Pass ref to Navbar */}
-      <main className="flex-grow" style={{ paddingTop: 'var(--navbar-height, 120px)' }}>
+      <main className="flex-grow" style={{ paddingTop: 'var(--content-padding-top, 120px)' }}>
         <Outlet /> {/* This is where nested route components (like Home, Login, etc.) will render */}
       </main>
       <Footer />

--- a/client/sanich-farms/src/components/Layout/Navbar/Navbar.jsx
+++ b/client/sanich-farms/src/components/Layout/Navbar/Navbar.jsx
@@ -43,7 +43,7 @@ const style = `
 }
 `;
 
-const Navbar = forwardRef(() => {
+const Navbar = forwardRef((_, ref) => {
   // Ref for dropdown close timeout
   const dropdownTimeoutRef = useRef(null);
 
@@ -64,8 +64,7 @@ const Navbar = forwardRef(() => {
     handleDesktopSearchSubmit,
     handleLogout,
     setShowShopDropdown,
-    searchInputRef,
-    navbarRef 
+    searchInputRef
   } = useNavbar();
 
   const { cartCount } = useCart();
@@ -128,7 +127,7 @@ const Navbar = forwardRef(() => {
 
   return (
     <header
-      ref={navbarRef}
+      ref={ref}
       className={`fixed top-0 z-50 w-full bg-white shadow-md font-poppins transition-all duration-500 ease-in-out
                  ${isNavbarHidden ? '-translate-y-full opacity-90' : 'translate-y-0 opacity-100'}
                  ${navbarAnimationClass}`}

--- a/client/sanich-farms/src/index.css
+++ b/client/sanich-farms/src/index.css
@@ -37,9 +37,9 @@ header {
   from { transform: translateY(-100%); opacity: 0; }
   to { transform: translateY(0); opacity: 1; }
 }
-@keyframes slideUp {
-  from { transform: translateY(100%); opacity: 0; }
-  to { transform: translateY(0); opacity: 1; }
+@keyframes slideUpHide {
+  from { transform: translateY(0); opacity: 1; }
+  to { transform: translateY(-100%); opacity: 0; }
 }
 @keyframes fadeAndScaleIn {
   from { opacity: 0; transform: scale(0.95); }
@@ -138,7 +138,7 @@ header {
   }
 
   .navbar-slide-up {
-    animation: slideUp 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+    animation: slideUpHide 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
   }
 
   /* Mobile menu content staggered animation */


### PR DESCRIPTION
- Enhanced MainLayout to calculate responsive content padding
- Added additional padding for larger screen sizes (md: +4px, lg: +8px)
- Fixed navbar animation keyframes (slideUpHide for proper hide animation)
- Improved navbar height calculation with responsive awareness
- Fixed forwardRef implementation in Navbar component
- Ensured breadcrumbs are properly visible on 1024px, 1440px, and tablet devices

This addresses the issue where breadcrumbs were being covered by the navbar on larger screen sizes due to inconsistent height calculations and z-index conflicts during navbar hide/show animations.