### PR TITLE
feat: implement clean card design with inline quantity selector

### DIFF
--- a/client/sanich-farms/src/components/Sections/Products/Products.jsx
+++ b/client/sanich-farms/src/components/Sections/Products/Products.jsx
@@ -56,8 +56,8 @@ const Products = () => {
 
         {/* Products Container */}
         {loading ? (
-          // Loading State - 4 skeleton cards
-          <div className="hidden sm:grid sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-12">
+          // Loading State - Responsive skeleton cards
+          <div className="hidden sm:grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6 mb-12">
             {[...Array(4)].map((_, i) => (
               <ProductCard key={`skeleton-${i}`} skeleton={true} />
             ))}
@@ -75,8 +75,8 @@ const Products = () => {
           </div>
         ) : featuredProducts.length > 0 ? (
           <>
-            {/* Desktop Grid - 4 columns */}
-            <div className="hidden sm:grid sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-12">
+            {/* Desktop Grid - Responsive 2/3/4 columns */}
+            <div className="hidden sm:grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6 mb-12">
               {featuredProducts.map((product, index) => (
                 <div
                   key={product.id}
@@ -88,18 +88,21 @@ const Products = () => {
               ))}
             </div>
 
-            {/* Mobile Horizontal Scroll */}
+            {/* Mobile Horizontal Scroll - Enhanced */}
             <div className="sm:hidden mb-12">
-              <div className="flex gap-4 overflow-x-auto pb-4 px-4 -mx-4 hide-scrollbar">
+              <div className="flex gap-3 sm:gap-4 overflow-x-auto pb-4 px-4 -mx-4 hide-scrollbar
+                           snap-x snap-mandatory touch-pan-x">
                 {featuredProducts.map((product, index) => (
                   <div
                     key={product.id}
-                    className="flex-shrink-0 w-48 animate-fadeIn"
+                    className="flex-shrink-0 w-44 xs:w-48 animate-fadeIn snap-start"
                     style={{ animationDelay: `${index * 0.1}s` }}
                   >
                     <ProductCard product={product} compact={true} />
                   </div>
                 ))}
+                {/* Add padding element for better scroll experience */}
+                <div className="flex-shrink-0 w-4"></div>
               </div>
             </div>
           </>

--- a/client/sanich-farms/src/components/UI/ProductCard.jsx
+++ b/client/sanich-farms/src/components/UI/ProductCard.jsx
@@ -70,7 +70,7 @@ const ProductCard = ({ product, skeleton = false, compact = false }) => {
     );
   }
 
-  // CART QUANTITY HANDLERS: Jumia-style quantity controls
+  // CART QUANTITY HANDLERS: Bottom quantity selector approach
   const handleAddToCart = () => {
     if (!isInCartAlready) {
       addToCart(product, 1);
@@ -197,61 +197,85 @@ const ProductCard = ({ product, skeleton = false, compact = false }) => {
           </div>
         </Link>
 
-          {/* Price and Add to Cart Button */}
-          <div className="mt-auto flex items-end justify-between gap-2">
-            {/* Price */}
-            <div className="flex flex-col">
-              <span className={`font-bold text-green-700 leading-none ${
-                compact ? 'text-sm' : 'text-base sm:text-lg'
-              }`}>
-                GH₵{parseFloat(product.price || 0).toFixed(2)}
-              </span>
-              {product.oldPrice && !compact && (
-                <span className="text-xs text-gray-500 line-through">
-                  GH₵{parseFloat(product.oldPrice || 0).toFixed(2)}
+          {/* Price Section - Clean Layout */}
+          <div className="mt-auto">
+            {/* Price Display */}
+            <div className="flex items-center justify-between gap-3 mb-2">
+              <div className="flex flex-col flex-grow">
+                <span className={`font-bold text-green-700 leading-none ${
+                  compact ? 'text-sm' : 'text-base sm:text-lg'
+                }`}>
+                  GH₵{parseFloat(product.price || 0).toFixed(2)}
                 </span>
+                {product.oldPrice && !compact && (
+                  <span className="text-xs text-gray-500 line-through mt-0.5">
+                    GH₵{parseFloat(product.oldPrice || 0).toFixed(2)}
+                  </span>
+                )}
+              </div>
+              
+              {/* Add to Cart Button - Only show when not in cart */}
+              {!isInCartAlready && (
+                <button
+                  onClick={handleAddToCart}
+                  className={`flex-shrink-0 bg-green-600 hover:bg-green-700 active:bg-green-800 
+                    text-white rounded-full shadow-md transition-all duration-200 
+                    flex items-center justify-center touch-manipulation font-medium
+                    ${compact 
+                      ? 'w-10 h-10 min-w-[40px] min-h-[40px] text-xs' 
+                      : 'w-12 h-12 min-w-[48px] min-h-[48px] sm:w-14 sm:h-14 sm:min-w-[56px] sm:min-h-[56px] text-sm'
+                    }`}
+                  aria-label="Add to cart"
+                >
+                  <FiShoppingCart size={compact ? 16 : 20} />
+                </button>
               )}
             </div>
-            
-            {/* Cart Controls - Jumia Style */}
-            {!isInCartAlready ? (
-              /* Add to Cart button */
-              <button
-                onClick={handleAddToCart}
-                className={`flex-shrink-0 bg-green-600 hover:bg-green-700 text-white rounded-full shadow-md transition duration-200 ${
-                  compact ? 'p-1.5' : 'p-2'
-                }`}
-                aria-label="Add to cart"
-              >
-                <FiShoppingCart size={compact ? 14 : 18} />
-              </button>
-            ) : (
-              /* Quantity Selector */
-              <div className={`flex items-center bg-green-600 text-white rounded-full shadow-md ${
-                compact ? 'text-xs' : 'text-sm'
-              }`}>
+
+            {/* Quantity Selector - Below price when item is in cart */}
+            {isInCartAlready && (
+              <div className={`flex items-center bg-green-600 text-white rounded-lg shadow-md
+                quantity-selector-slide transition-all duration-300 ease-in-out
+                ${compact 
+                  ? 'h-10 min-h-[40px] text-sm' 
+                  : 'h-12 min-h-[48px] sm:h-14 sm:min-h-[56px] text-base'
+                }`}>
+                
+                {/* Decrease Button */}
                 <button
                   onClick={handleDecreaseQuantity}
-                  className={`hover:bg-green-700 rounded-full transition duration-200 ${
-                    compact ? 'p-1' : 'p-1.5'
-                  }`}
+                  className={`flex items-center justify-center hover:bg-green-700 active:bg-green-800 
+                    transition-all duration-200 touch-manipulation rounded-l-lg flex-shrink-0
+                    ${compact 
+                      ? 'w-10 h-10 min-w-[40px] min-h-[40px]' 
+                      : 'w-12 h-12 min-w-[48px] min-h-[48px] sm:w-14 sm:h-14 sm:min-w-[56px] sm:min-h-[56px]'
+                    }`}
                   aria-label="Decrease quantity"
                 >
-                  <FiMinus size={compact ? 12 : 14} />
+                  <FiMinus size={compact ? 14 : 18} />
                 </button>
-                <span className={`font-medium min-w-8 text-center ${
-                  compact ? 'mx-1 text-xs' : 'mx-2 text-sm'
-                }`}>
+                
+                {/* Quantity Display */}
+                <div className={`font-bold text-center flex-grow
+                  ${compact 
+                    ? 'text-sm px-2' 
+                    : 'text-base sm:text-lg px-3'
+                  }`}>
                   {cartQuantity}
-                </span>
+                </div>
+                
+                {/* Increase Button */}
                 <button
                   onClick={handleIncreaseQuantity}
-                  className={`hover:bg-green-700 rounded-full transition duration-200 ${
-                    compact ? 'p-1' : 'p-1.5'
-                  }`}
+                  className={`flex items-center justify-center hover:bg-green-700 active:bg-green-800 
+                    transition-all duration-200 touch-manipulation rounded-r-lg flex-shrink-0
+                    ${compact 
+                      ? 'w-10 h-10 min-w-[40px] min-h-[40px]' 
+                      : 'w-12 h-12 min-w-[48px] min-h-[48px] sm:w-14 sm:h-14 sm:min-w-[56px] sm:min-h-[56px]'
+                    }`}
                   aria-label="Increase quantity"
                 >
-                  <FiPlus size={compact ? 12 : 14} />
+                  <FiPlus size={compact ? 14 : 18} />
                 </button>
               </div>
             )}

--- a/client/sanich-farms/src/index.css
+++ b/client/sanich-farms/src/index.css
@@ -117,7 +117,53 @@ header {
     max-width: 100vw;
     box-sizing: border-box;
   }
+}
+
+/* --- Cart Quantity Selector Animation --- */
+@keyframes slideInUp {
+  from {
+    opacity: 0;
+    transform: translateY(5px) scaleY(0.8);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scaleY(1);
+  }
+}
+
+.quantity-selector-slide {
+  animation: slideInUp 0.25s ease-out forwards;
+  transform-origin: top;
+}
+
+/* --- Extra Small Device Optimizations --- */
+@media (max-width: 384px) {
+  /* Optimize for very small screens like iPhone SE */
+  .product-card-compact {
+    min-width: 160px !important;
+  }
   
+  /* Prevent cart controls from being too small on tiny screens */
+  .cart-control-min-size {
+    min-width: 32px !important;
+    min-height: 32px !important;
+  }
+}
+
+/* --- Small Device Optimizations (384px - 640px) --- */
+@media (min-width: 384px) and (max-width: 640px) {
+  .quantity-selector-compact {
+    min-height: 36px !important;
+  }
+  
+  .quantity-selector-compact .quantity-btn {
+    min-width: 36px !important;
+    min-height: 36px !important;
+  }
+}
+
+/* --- Mobile Menu Specific Styles --- */
+@media (max-width: 1024px) {
   /* Mobile menu specific z-index fixes and full screen coverage */
   .mobile-menu-overlay {
     z-index: 10000 !important;

--- a/client/sanich-farms/tailwind.config.js
+++ b/client/sanich-farms/tailwind.config.js
@@ -5,9 +5,14 @@ module.exports = {
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      screens: {
+        'xs': '384px',
+        // => @media (min-width: 384px) { ... }
+      },
+    },
   },
   plugins: [
-    require('@tailwindcss/line-clamp'), // <-- This is the line to add
+    require('@tailwindcss/line-clamp'),
   ],
 };


### PR DESCRIPTION
- Hide quantity selector when item not in cart for cleaner look
- Hide add-to-cart button when item is added to cart
- Show quantity selector inline below price after adding to cart
- Bigger add-to-cart buttons (40px compact, 48-56px regular)
- Smooth slide-in animation for quantity selector appearance
- Rectangular quantity selector design with rounded corners
- Fully responsive across all devices (iPhone SE to Desktop)
- Improved touch targets and accessibility
- Clean visual hierarchy with proper spacing